### PR TITLE
fix: edit set screen notes lagging

### DIFF
--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/set/EditSetScreen.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/set/EditSetScreen.kt
@@ -271,7 +271,7 @@ fun EditSetScreen(
                         stringResource(Res.string.edit_set_screen_extra_notes_label),
                         style = MaterialTheme.typography.titleMedium
                     )
-                    var notes by remember(set.notes) { mutableStateOf(set.notes) }
+                    var notes by remember { mutableStateOf(set.notes) }
 
                     TextField(
                         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
Remove the key from the remember call in the edit set screen for editing notes to avoid state discrepencies

fixes #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where user notes would unexpectedly reset during screen updates. Notes are now properly preserved across recompositions, providing a more stable editing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->