### PR TITLE
Refactors set variation display logic

### DIFF
--- a/data/client/src/commonMain/kotlin/com/lift/bro/data/client/datasources/KtorSetDataSource.kt
+++ b/data/client/src/commonMain/kotlin/com/lift/bro/data/client/datasources/KtorSetDataSource.kt
@@ -4,6 +4,7 @@ import com.lift.bro.data.client.createConnectionFlow
 import com.lift.bro.data.core.datasource.SetDataSource
 import com.lift.bro.domain.models.LBSet
 import com.lift.bro.domain.models.VariationId
+import com.lift.bro.domain.repositories.Sorting
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
@@ -12,16 +13,19 @@ import kotlinx.datetime.LocalDate
 class KtorSetDataSource(
     private val httpClient: HttpClient,
 ): SetDataSource {
+
     override fun listenAll(
         startDate: LocalDate?,
         endDate: LocalDate?,
         variationId: String?,
         limit: Long,
+        sorting: Sorting
     ): Flow<List<LBSet>> = createConnectionFlow(httpClient, "api/ws/sets?limit=$limit&startDate=$startDate&endDate=$endDate&variationId=$variationId")
 
     override fun listenAllForLift(
         liftId: String,
         limit: Long,
+        sorting: Sorting
     ): Flow<List<LBSet>> = createConnectionFlow(httpClient, "api/ws/sets?limit=$limit&liftId=$liftId")
 
     override fun listen(id: String): Flow<LBSet?> = createConnectionFlow(httpClient, "api/ws/sets?setId=$id")

--- a/data/core/src/commonMain/kotlin/com/lift/bro/data/core/datasource/SetDataSource.kt
+++ b/data/core/src/commonMain/kotlin/com/lift/bro/data/core/datasource/SetDataSource.kt
@@ -2,12 +2,26 @@ package com.lift.bro.data.core.datasource
 
 import com.lift.bro.domain.models.LBSet
 import com.lift.bro.domain.models.VariationId
+import com.lift.bro.domain.repositories.Sorting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
 interface SetDataSource {
-    fun listenAll(startDate: LocalDate?, endDate: LocalDate?, variationId: String?, limit: Long): Flow<List<LBSet>>
-    fun listenAllForLift(liftId: String, limit: Long = Long.MAX_VALUE): Flow<List<LBSet>>
+
+    fun listenAll(
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        variationId: String?,
+        limit: Long,
+        sorting: Sorting = Sorting.date,
+    ): Flow<List<LBSet>>
+
+    fun listenAllForLift(
+        liftId: String,
+        limit: Long = Long.MAX_VALUE,
+        sorting: Sorting = Sorting.date,
+    ): Flow<List<LBSet>>
+
     fun listen(id: String): Flow<LBSet?>
     suspend fun save(lbSet: LBSet)
     suspend fun delete(lbSet: LBSet)

--- a/data/core/src/commonMain/kotlin/com/lift/bro/data/core/repository/SetRepository.kt
+++ b/data/core/src/commonMain/kotlin/com/lift/bro/data/core/repository/SetRepository.kt
@@ -4,6 +4,7 @@ import com.lift.bro.data.core.datasource.SetDataSource
 import com.lift.bro.domain.models.LBSet
 import com.lift.bro.domain.models.VariationId
 import com.lift.bro.domain.repositories.ISetRepository
+import com.lift.bro.domain.repositories.Sorting
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
@@ -16,14 +17,16 @@ class SetRepository(
         endDate: LocalDate?,
         variationId: String?,
         limit: Long,
-    ): Flow<List<LBSet>> = local.listenAll(startDate, endDate, variationId, limit)
+        sorting: Sorting
+    ): Flow<List<LBSet>> = local.listenAll(startDate, endDate, variationId, limit, sorting)
 
     override fun listenAllForLift(
         liftId: String,
         startDate: LocalDate?,
         endDate: LocalDate?,
-        limit: Long
-    ): Flow<List<LBSet>> = local.listenAllForLift(liftId, limit)
+        limit: Long,
+        sorting: Sorting
+    ): Flow<List<LBSet>> = local.listenAllForLift(liftId, limit, sorting)
 
     override fun listen(id: String): Flow<LBSet?> = local.listen(id)
     override suspend fun save(lbSet: LBSet) = local.save(lbSet)

--- a/data/sqldelight/src/commonMain/kotlin/com/lift/bro/data/sqldelight/datasource/SqlDelightVariationDataSource.kt
+++ b/data/sqldelight/src/commonMain/kotlin/com/lift/bro/data/sqldelight/datasource/SqlDelightVariationDataSource.kt
@@ -7,6 +7,7 @@ import com.lift.bro.data.core.datasource.VariationDataSource
 import com.lift.bro.domain.models.LBSet
 import com.lift.bro.domain.models.Lift
 import com.lift.bro.domain.models.Variation
+import com.lift.bro.domain.repositories.Sorting
 import comliftbrodb.LiftQueries
 import comliftbrodb.LiftingSet
 import comliftbrodb.SetQueries
@@ -93,11 +94,13 @@ class SqlDelightVariationDataSource(
     override fun listenAllForLift(liftId: String?): Flow<List<Variation>> =
         combine(
             variationQueries.getAllForLift(liftId).asFlowList(),
+
             setQueries.getAll(
                 limit = Long.MAX_VALUE,
                 startDate = Instant.DISTANT_PAST,
                 endDate = Instant.DISTANT_FUTURE,
-                variationId = null
+                variationId = null,
+                sortBy = Sorting.date.toString()
             ).asFlowList(),
         ) { variations: List<GetAllForLift>, sets: List<LiftingSet> ->
             variations.map { variation ->
@@ -127,7 +130,8 @@ class SqlDelightVariationDataSource(
             limit = Long.MAX_VALUE,
             startDate = Instant.DISTANT_PAST,
             endDate = Instant.DISTANT_FUTURE,
-            variationId = null
+            variationId = null,
+            sortBy = Sorting.date.toString(),
         ).executeAsList().map { it.toDomain() }
         return variationQueries.getAll().executeAsList().map { variation ->
             Variation(

--- a/data/sqldelight/src/commonMain/kotlin/com/lift/bro/data/sqldelight/datasource/SqldelightSetDataSource.kt
+++ b/data/sqldelight/src/commonMain/kotlin/com/lift/bro/data/sqldelight/datasource/SqldelightSetDataSource.kt
@@ -7,6 +7,7 @@ import com.lift.bro.data.core.datasource.SetDataSource
 import com.lift.bro.domain.models.LBSet
 import com.lift.bro.domain.models.Tempo
 import com.lift.bro.domain.models.VariationId
+import com.lift.bro.domain.repositories.Sorting
 import comliftbrodb.LiftingSet
 import comliftbrodb.SetQueries
 import kotlinx.coroutines.CoroutineDispatcher
@@ -28,12 +29,19 @@ class SqldelightSetDataSource(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ): SetDataSource {
 
-    override fun listenAll(startDate: LocalDate?, endDate: LocalDate?, variationId: String?, limit: Long): Flow<List<LBSet>> {
+    override fun listenAll(
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        variationId: String?,
+        limit: Long,
+        sorting: Sorting,
+    ): Flow<List<LBSet>> {
         return setQueries.getAll(
             startDate = startDate?.atStartOfDayIn(),
             endDate = endDate?.atEndOfDayIn(),
             variationId = variationId,
             limit = limit,
+            sortBy = sorting.toString(),
         )
             .asFlow().mapToList(dispatcher)
             .map { sets ->
@@ -55,12 +63,13 @@ class SqldelightSetDataSource(
             }
     }
 
-    override fun listenAllForLift(liftId: String, limit: Long): Flow<List<LBSet>> =
+    override fun listenAllForLift(liftId: String, limit: Long, sorting: Sorting): Flow<List<LBSet>> =
         setQueries.getAllForLift(
             liftId = liftId,
             startDate = Instant.DISTANT_PAST,
             endDate = Instant.DISTANT_FUTURE,
-            limit = limit
+            limit = limit,
+            sortBy = sorting.toString()
         )
             .asFlow().mapToList(dispatcher)
             .map {

--- a/data/sqldelight/src/commonMain/sqldelight/com.lift.bro.db/Set.sq
+++ b/data/sqldelight/src/commonMain/sqldelight/com.lift.bro.db/Set.sq
@@ -46,16 +46,24 @@ SELECT * FROM LiftingSet
 WHERE (date >= :startDate OR :startDate = NULL)
 AND (date <= :endDate OR :endDate = NULL)
 AND (variationId = :variationId OR :variationId = NULL)
-ORDER BY date DESC
+ORDER BY
+    CASE :sortBy
+        WHEN 'weight' THEN weight
+        ELSE date
+    END DESC
 LIMIT :limit;
 
 getAllForLift:
 SELECT * FROM LiftingSet
 JOIN Variation ON Variation.id = LiftingSet.variationId
 WHERE Variation.liftId = :liftId
-AND date >= :startDate OR :startDate = NULL
-AND date <= :endDate OR :endDate = NULL
-ORDER BY date DESC
+AND (date >= :startDate OR :startDate = NULL)
+AND (date <= :endDate OR :endDate = NULL)
+ORDER BY
+    CASE :sortBy
+        WHEN 'weight' THEN weight
+        ELSE date
+    END DESC
 LIMIT :limit;
 
 getByWorkoutId:

--- a/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISetRepository.kt
+++ b/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISetRepository.kt
@@ -5,20 +5,26 @@ import com.lift.bro.domain.models.VariationId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.datetime.LocalDate
 
+enum class Sorting {
+    weight, date
+}
+
 interface ISetRepository {
 
     fun listenAll(
         startDate: LocalDate? = null,
         endDate: LocalDate? = null,
         variationId: String? = null,
-        limit: Long = Long.MAX_VALUE
+        limit: Long = Long.MAX_VALUE,
+        sorting: Sorting = Sorting.date
     ): Flow<List<LBSet>>
 
     fun listenAllForLift(
         liftId: String,
         startDate: LocalDate? = null,
         endDate: LocalDate? = null,
-        limit: Long = Long.MAX_VALUE
+        limit: Long = Long.MAX_VALUE,
+        sorting: Sorting = Sorting.date
     ): Flow<List<LBSet>>
 
     fun listen(id: String): Flow<LBSet?>

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/LBDatabase.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/LBDatabase.kt
@@ -19,6 +19,7 @@ import com.lift.bro.domain.models.Variation
 import com.lift.bro.domain.models.calculateMax
 import com.lift.bro.domain.models.estimatedMax
 import com.lift.bro.domain.repositories.ISetRepository
+import com.lift.bro.domain.repositories.Sorting
 import com.lift.bro.utils.mapEach
 import com.lift.bro.utils.toLocalDate
 import comliftbrodb.GetAllByVariation
@@ -206,7 +207,8 @@ class SetDataSource(
             limit = limit,
             startDate = startDate,
             endDate = endDate,
-            variationId = variationId
+            variationId = variationId,
+            sortBy = Sorting.date.toString()
         ).executeAsList().map { it.toDomain() }
 
     fun LocalDate.atStartOfDayIn(): Instant = this.atStartOfDayIn(TimeZone.currentSystemDefault())


### PR DESCRIPTION
- Improves the display of set variations by showing the percentage of the lift max or variation max, when available.
- Uses annotated strings for richer text formatting.
- Shows variation selection when not selected.

fixes #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Select Variation" button for sets without a selected variation
  * New sorting option for set listings (date/weight)

* **UI/UX Improvements**
  * Shows max-percentage indicators for lifts and variations
  * Center-aligned, simplified set title text and refined padding/clip
  * Larger, more accessible clickable areas for set items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->