### PR TITLE
Enable composite builds for flowvi

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -140,3 +140,22 @@ tasks.register("generateArchDiagram") {
 tasks.register("clean", Delete::class) {
     delete(rootProject.buildDir)
 }
+
+tasks.register("enableLocalFlowvi") {
+    group = "flowvi"
+    doLast {
+        with(file("libs/flowvi/enablecompositebuilds")) {
+            parentFile.mkdirs()
+            createNewFile()
+        }
+    }
+}
+
+tasks.register("disableLocalFlowvi") {
+    group = "flowvi"
+    doLast {
+        with(file("libs/flowvi/enablecompositebuilds")) {
+            if (exists()) delete()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.*
+
 pluginManagement {
     resolutionStrategy {
         eachPlugin {
@@ -34,11 +36,21 @@ include(":presentation:server")
 include(":data:sqldelight")
 include(":data:core")
 
-//include(":libs:flowvi:core")
-//include(":libs:flowvi:compose")
 include(":libs:logging")
 include(":libs:ext:flow")
 include(":libs:ext:ktx-datetime")
 include(":libs:ext:compose")
 include(":libs:navi")
 include(":libs:screenshot-processor")
+
+
+if (file("libs/flowvi/enablecompositebuilds").exists()) {
+    includeBuild("libs/flowvi") {
+        dependencySubstitution {
+            substitute(module("tv.dpal:flowvi-core")).using(project(":core"))
+        }
+        dependencySubstitution {
+            substitute(module("tv.dpal:flowvi-compose")).using(project(":compose"))
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added build tasks to enable and disable local composite builds for the flowvi library, facilitating flexible dependency management during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->