### PR TITLE
Update platform context to force assignment

### DIFF
--- a/app-android/src/main/java/com/lift/bro/android/MainActivity.kt
+++ b/app-android/src/main/java/com/lift/bro/android/MainActivity.kt
@@ -13,6 +13,7 @@ import com.lift.bro.di.DependencyContainer
 import com.lift.bro.presentation.App
 import com.lift.bro.presentation.LocalPlatformContext
 import com.lift.bro.presentation.LocalServer
+import com.lift.bro.presentation.Platform
 import com.lift.bro.presentation.StoreManager
 import com.lift.bro.presentation.server.createLiftBroServer
 import com.lift.bro.ui.navigation.Destination
@@ -31,7 +32,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val coordinator = rememberNavCoordinator(Destination.Unknown)
             CompositionLocalProvider(
-                LocalPlatformContext provides LocalContext.current,
+                LocalPlatformContext provides Platform.Android(LocalContext.current),
                 LocalServer provides createLiftBroServer()
             ) {
                 App(

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/App.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/App.kt
@@ -105,7 +105,13 @@ val LocalEMaxSettings = compositionLocalOf<Boolean> {
     error("Show eMax was not set")
 }
 
-val LocalPlatformContext = compositionLocalOf<Any?> {
+val LocalPlatformContext = compositionLocalOf<Platform> {
+    error("Platform was not set")
+}
+
+sealed interface Platform {
+    data class Android(val context: Any): Platform
+    data object iOS: Platform
 }
 
 val LocalTMaxSettings = compositionLocalOf<Boolean> {
@@ -175,7 +181,7 @@ fun App(
     navCoordinator: NavCoordinator = rememberNavCoordinator<tv.dpal.navi.Destination>(Destination.Unknown),
 ) {
     val subscriptionType = remember { mutableStateOf(SubscriptionType.None) }
-    val isAndroid = LocalPlatformContext.current != null
+    val isAndroid = LocalPlatformContext.current is Platform.Android
 
     LaunchedEffect("setup_revenuecat") {
         if (BuildConfig.isDebug) {
@@ -239,7 +245,7 @@ fun App(
             }
 
             if (!BuildConfig.isDebug) {
-                Firebase.initialize(context)
+                Firebase.initialize((context as? Platform.Android)?.context)
             }
         }
 

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/SettingsScreen.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/SettingsScreen.kt
@@ -39,7 +39,6 @@ import com.lift.bro.di.dependencies
 import com.lift.bro.domain.models.LiftBro
 import com.lift.bro.domain.models.SubscriptionType
 import com.lift.bro.presentation.LocalLiftBro
-import com.lift.bro.presentation.LocalPlatformContext
 import com.lift.bro.presentation.LocalServer
 import com.lift.bro.presentation.LocalSubscriptionStatusProvider
 import com.lift.bro.presentation.home.iconRes
@@ -86,7 +85,6 @@ fun SettingsScreen() {
 
             var subscriptionType by LocalSubscriptionStatusProvider.current
             val localServer = LocalServer.current
-            val showPro = LocalPlatformContext.current != null // (this means its iOS)
 
             LazyColumn(
                 modifier = Modifier.padding(padding),
@@ -144,45 +142,43 @@ fun SettingsScreen() {
                     ThemeSettingsRow()
                 }
 
-                if (showPro) {
-                    item {
-                        Text(
-                            modifier = Modifier.semantics {
-                                heading()
-                            },
-                            text = stringResource(Res.string.settings_pro_features_header),
-                            style = MaterialTheme.typography.headlineMedium,
-                        )
-                    }
+                item {
+                    Text(
+                        modifier = Modifier.semantics {
+                            heading()
+                        },
+                        text = stringResource(Res.string.settings_pro_features_header),
+                        style = MaterialTheme.typography.headlineMedium,
+                    )
+                }
 
-                    item {
-                        when (subscriptionType) {
-                            SubscriptionType.None -> {
-                                SettingsRowItem(
-                                    modifier = Modifier.clickable { showPaywall = true },
-                                    title = { Text(stringResource(Res.string.settings_become_pro_title)) },
-                                ) {
-                                    Row {
-                                        Text(stringResource(Res.string.settings_become_pro_description))
-                                    }
+                item {
+                    when (subscriptionType) {
+                        SubscriptionType.None -> {
+                            SettingsRowItem(
+                                modifier = Modifier.clickable { showPaywall = true },
+                                title = { Text(stringResource(Res.string.settings_become_pro_title)) },
+                            ) {
+                                Row {
+                                    Text(stringResource(Res.string.settings_become_pro_description))
                                 }
                             }
-
-                            else -> {}
                         }
 
-                        LaunchedEffect(showPaywall) {
-                            Purchases.sharedInstance.getCustomerInfo(
-                                onError = { error ->
-                                    Sentry.captureException(Throwable(message = error.message))
-                                },
-                                onSuccess = { success ->
-                                    if (success.entitlements.active.containsKey("pro")) {
-                                        subscriptionType = SubscriptionType.Pro
-                                    }
+                        else -> {}
+                    }
+
+                    LaunchedEffect(showPaywall) {
+                        Purchases.sharedInstance.getCustomerInfo(
+                            onError = { error ->
+                                Sentry.captureException(Throwable(message = error.message))
+                            },
+                            onSuccess = { success ->
+                                if (success.entitlements.active.containsKey("pro")) {
+                                    subscriptionType = SubscriptionType.Pro
                                 }
-                            )
-                        }
+                            }
+                        )
                     }
                 }
 
@@ -225,22 +221,20 @@ fun SettingsScreen() {
                                 }
                             )
 
-                            if (showPro || subscriptionType == SubscriptionType.Pro && localServer != null) {
+                            if (subscriptionType == SubscriptionType.Pro && localServer != null) {
                                 SettingsRowItem(
                                     modifier = Modifier.padding(top = MaterialTheme.spacing.half),
                                     backgroundColor = MaterialTheme.colorScheme.surfaceContainer,
                                     title = { Text("Lift Pros Only \uD83D\uDE0E") }
                                 ) {
-                                    if (localServer != null) {
-                                        ServerSettingsRow(localServer)
-                                    }
+                                    ServerSettingsRow(localServer)
                                 }
                             }
                         }
                     }
                 }
 
-                if (showPro || subscriptionType == SubscriptionType.Pro) {
+                if (subscriptionType == SubscriptionType.Pro) {
                     item {
                         MERSettingsRow()
                     }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/utils/PreviewAppTheme.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/utils/PreviewAppTheme.kt
@@ -27,6 +27,7 @@ import com.lift.bro.presentation.LocalSubscriptionStatusProvider
 import com.lift.bro.presentation.LocalTMaxSettings
 import com.lift.bro.presentation.LocalTwmSettings
 import com.lift.bro.presentation.LocalUnitOfMeasure
+import com.lift.bro.presentation.Platform
 import com.lift.bro.ui.card.lift.LiftCardYValue
 import com.lift.bro.ui.navigation.Destination
 import com.lift.bro.ui.theme.spacing
@@ -52,7 +53,7 @@ internal fun PreviewAppTheme(
         LocalCalculatorVisibility provides calculatorVisibility,
         LocalSubscriptionStatusProvider provides subscriptionType,
         LocalLiftCardYValue provides mutableStateOf(LiftCardYValue.Weight),
-        LocalPlatformContext provides null,
+        LocalPlatformContext provides Platform.iOS,
         LocalServer provides null,
         LocalEMaxSettings provides true,
         LocalTMaxSettings provides true,

--- a/presentation/compose/src/iosMain/kotlin/com/lift/bro/MainViewController.kt
+++ b/presentation/compose/src/iosMain/kotlin/com/lift/bro/MainViewController.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.window.ComposeUIViewController
 import com.lift.bro.presentation.App
 import com.lift.bro.presentation.LocalAdBannerProvider
+import com.lift.bro.presentation.LocalPlatformContext
+import com.lift.bro.presentation.Platform
 import platform.UIKit.UIView
 
 fun MainViewController(
@@ -17,14 +19,18 @@ fun MainViewController(
         LocalAdBannerProvider provides bannerProvider
     ) {
         val keyboard = LocalSoftwareKeyboardController.current
-        App(
-            modifier = Modifier.pointerInput(Unit) {
-                detectTapGestures(
-                    onTap = {
-                        keyboard?.hide()
-                    },
-                )
-            }
-        )
+        CompositionLocalProvider(
+            LocalPlatformContext provides Platform.iOS
+        ) {
+            App(
+                modifier = Modifier.pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = {
+                            keyboard?.hide()
+                        },
+                    )
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
create enum for Android/iOS and pass context in through android. Forcing each platform to implement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal platform context handling for better reliability across Android and iOS.
  * Settings screen premium features are now consistently gated by subscription status rather than platform availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->