### PR TITLE
Update Dashboard Banner with carousel of banners instead of static ones

### DIFF
--- a/presentation/compose/src/commonMain/composeResources/files/release_notes.json
+++ b/presentation/compose/src/commonMain/composeResources/files/release_notes.json
@@ -8,14 +8,6 @@
         }
     },
     {
-        "versionId": "2026.05.18",
-        "type": "feature",
-        "platform": "all",
-        "note": {
-            "en": "Convert Lifts to Categories, and Variations to Movements"
-        }
-    },
-    {
         "versionId": "2025.08.30",
         "type": "feature",
         "platform": "all",

--- a/presentation/compose/src/commonMain/composeResources/files/release_notes.json
+++ b/presentation/compose/src/commonMain/composeResources/files/release_notes.json
@@ -1,98 +1,114 @@
 [
-  {
-    "versionId": "2025.08.30",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Engineering Refactor!!!"
+    {
+        "versionId": "2026.05.18",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Convert Lifts to Categories, and Variations to Movements"
+        }
+    },
+    {
+        "versionId": "2026.05.18",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Convert Lifts to Categories, and Variations to Movements"
+        }
+    },
+    {
+        "versionId": "2025.08.30",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Engineering Refactor!!!"
+        }
+    },
+    {
+        "versionId": "2025.08.30",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Update lift details UI"
+        }
+    },
+    {
+        "versionId": "2025.08.30",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Add \"Today\" button to workout calendar"
+        }
+    },
+    {
+        "versionId": "2025.08.30",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Update Calendar with new Workout Flow"
+        }
+    },
+    {
+        "versionId": "2025.08.30",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Update Set Screen with new Variation Search Dialog"
+        }
+    },
+    {
+        "versionId": "2025.08.16",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Add notes per variation, Remember to squeeze that peach!"
+        }
+    },
+    {
+        "versionId": "2025.08.16",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Become a LIFT PRO!!!!!!"
+        }
+    },
+    {
+        "versionId": "2025.08.03",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Add \"favouruite\" variation feature, highlighting your favourite variation of any given lift!"
+        }
+    },
+    {
+        "versionId": "2025.08.03",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Fix MER Calculations"
+        }
+    },
+    {
+        "versionId": "2025.08.03",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Add sorting to variation details"
+        }
+    },
+    {
+        "versionId": "2025.08.03",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Dashboard UI Improvements (move some buttons around)"
+        }
+    },
+    {
+        "versionId": "2025.08.03",
+        "type": "feature",
+        "platform": "all",
+        "note": {
+            "en": "Add estimated and theoretical maxes for pro users"
+        }
     }
-  },
-  {
-    "versionId": "2025.08.30",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Update lift details UI"
-    }
-  },
-  {
-    "versionId": "2025.08.30",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Add \"Today\" button to workout calendar"
-    }
-  },
-  {
-    "versionId": "2025.08.30",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Update Calendar with new Workout Flow"
-    }
-  },
-  {
-    "versionId": "2025.08.30",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Update Set Screen with new Variation Search Dialog"
-    }
-  },
-  {
-    "versionId": "2025.08.16",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Add notes per variation, Remember to squeeze that peach!"
-    }
-  },
-  {
-    "versionId": "2025.08.16",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Become a LIFT PRO!!!!!!"
-    }
-  },
-  {
-    "versionId": "2025.08.03",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Add \"favouruite\" variation feature, highlighting your favourite variation of any given lift!"
-    }
-  },
-  {
-    "versionId": "2025.08.03",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Fix MER Calculations"
-    }
-  },
-  {
-    "versionId": "2025.08.03",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Add sorting to variation details"
-    }
-  },
-  {
-    "versionId": "2025.08.03",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Dashboard UI Improvements (move some buttons around)"
-    }
-  },
-  {
-    "versionId": "2025.08.03",
-    "type": "feature",
-    "platform": "all",
-    "note": {
-      "en": "Add estimated and theoretical maxes for pro users"
-    }
-  }
 ]

--- a/presentation/compose/src/commonMain/composeResources/values/strings.xml
+++ b/presentation/compose/src/commonMain/composeResources/values/strings.xml
@@ -1,6 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <resources><string name="app_congrats_text">Congrats!!</string>
 
+    <string name="analytics_consent_banner_action">Enable</string>
+    <string name="analytics_consent_banner_detail">Share usage info (Screen Names, Button Clicks)</string>
+    <string name="analytics_consent_banner_onclick_label">Enable Analytics</string>
+    <string name="analytics_consent_banner_privacy">NO personal info</string>
+    <string name="analytics_consent_banner_title">Help Lift Bro improve!</string>
+
     <string name="backup_dialog_message">Lift Bro is a local only application, If you lose your phone all your data is gone! Would you like to backup now?</string>
     <string name="backup_dialog_primary_cta">Backup Now</string>
     <string name="backup_dialog_secondary_cta">Ignore</string>
@@ -34,6 +40,7 @@
     <string name="dashboard_footer_leading_button_content_description">Dashboard</string>
     <string name="dashboard_footer_trailing_button_content_description">Calendar</string>
     <string name="dashboard_footer_version">Version: %1$s</string>
+    <string name="dashboard_lift_header_title">Categories</string>
     <string name="dashboard_title">LIFT BRO</string>
     <string name="dashboard_toolbar_leading_button_content_description">Settings</string>
     <string name="dashboard_toolbar_trailing_button_content_description">Add Lift</string>
@@ -126,7 +133,7 @@ Soreness or pain?</string>
     <string name="radio_field_unselected_option_text">Unselected option</string>
 
     <string name="release_notes_dialog_title">Release Notes</string>
-    <string name="release_notes_row_ignore_content_description">Ignore Release Notes</string>
+    <string name="release_notes_release_notes_close_content_description">Ignore Release Notes</string>
     <string name="release_notes_row_new_update_title">New Update Downloaded!</string>
     <string name="release_notes_row_tap_subtitle">Tap to see Release Notes</string>
     <string name="rep_weight_selector_info_p1">A Scale that can be used to track the effort used for a given set</string>

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardInteractor.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardInteractor.kt
@@ -48,7 +48,7 @@ sealed class DashboardListItem {
     data class LiftHeader(val v3: Boolean): DashboardListItem()
 
     @Serializable
-    data object AnalyticsBanner: DashboardListItem()
+    data object Banner: DashboardListItem()
 
     @Serializable
     sealed class LiftCard: DashboardListItem() {
@@ -59,9 +59,6 @@ sealed class DashboardListItem {
         @Serializable
         data object Loading: LiftCard()
     }
-
-    @Serializable
-    data object ReleaseNotes: DashboardListItem()
 
     @Serializable
     data object WorkoutCalendar: DashboardListItem()
@@ -84,8 +81,6 @@ data class SortingSettings(
 sealed interface DashboardEvent {
     data object AddLiftClicked: DashboardEvent
     data class LiftClicked(val liftId: String): DashboardEvent
-    data object EnableAnalytics: DashboardEvent
-    data object DismissAnalyticsBanner: DashboardEvent
     data class SortingOptionSelected(val sortingOption: SortingOption): DashboardEvent
     data object FavouritesAtTopToggled: DashboardEvent
 }
@@ -105,20 +100,6 @@ fun rememberDashboardInteractor(
             when (event) {
                 DashboardEvent.AddLiftClicked -> navCoordinator.present(Destination.CreateCategory())
                 is DashboardEvent.LiftClicked -> navCoordinator.present(Destination.CategoryDetails(event.liftId))
-                DashboardEvent.EnableAnalytics -> {
-                    settingsRepository.set(
-                        Setting.AnalyticsConsent,
-                        AnalyticsConsent(true, true)
-                    )
-                    dependencies.analytics.setConsent(true)
-                }
-                DashboardEvent.DismissAnalyticsBanner -> {
-                    settingsRepository.set(
-                        Setting.AnalyticsConsent,
-                        AnalyticsConsent(true, false)
-                    )
-                    dependencies.analytics.setConsent(false)
-                }
                 else -> {}
             }
         }
@@ -128,9 +109,8 @@ fun rememberDashboardInteractor(
         combine(
             liftRepository.listenAll().onStart { emit(emptyList()) },
             variationRepository.listenAll().onStart { emit(emptyList()) },
-            settingsRepository.listen(Setting.AnalyticsConsent),
-        ) { lifts, variations, consent -> Triple(lifts, variations, consent) }
-            .flatMapLatest { (lifts, variations, consent) ->
+        ) { lifts, variations -> lifts to variations }
+            .flatMapLatest { (lifts, variations) ->
                 val variationsByLift = variations.groupBy { it.lift?.id }
                 val cards: List<Flow<DashboardListItem?>> = lifts.map { lift ->
                     val liftVariations = variationsByLift[lift.id] ?: emptyList()
@@ -171,19 +151,13 @@ fun rememberDashboardInteractor(
                             items = items.toMutableList().apply {
                                 if (!v3) {
                                     // lift header at top if not v3
-                                    add(0, DashboardListItem.ReleaseNotes)
-                                    if (!consent.dashboardBannerDismissed) {
-                                        add(0, DashboardListItem.AnalyticsBanner)
-                                    }
+                                    add(0, DashboardListItem.Banner)
                                     add(0, DashboardListItem.LiftHeader(v3))
                                 } else {
                                     // release notes -> workout calendar -> lift header
                                     add(0, DashboardListItem.LiftHeader(v3))
                                     add(0, DashboardListItem.WorkoutCalendar)
-                                    add(0, DashboardListItem.ReleaseNotes)
-                                    if (!consent.dashboardBannerDismissed) {
-                                        add(0, DashboardListItem.AnalyticsBanner)
-                                    }
+                                    add(0, DashboardListItem.Banner)
                                 }
                             },
                             sortingSettings = if (state is Loaded) state.sortingSettings else SortingSettings()

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardInteractor.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardInteractor.kt
@@ -5,11 +5,9 @@ import com.lift.bro.data.LiftDataSource
 import com.lift.bro.di.dependencies
 import com.lift.bro.di.setRepository
 import com.lift.bro.di.variationRepository
-import com.lift.bro.domain.models.settings.AnalyticsConsent
 import com.lift.bro.domain.repositories.ISetRepository
 import com.lift.bro.domain.repositories.ISettingsRepository
 import com.lift.bro.domain.repositories.IVariationRepository
-import com.lift.bro.domain.repositories.Setting
 import com.lift.bro.ui.card.lift.LiftCardData
 import com.lift.bro.ui.card.lift.LiftCardState
 import com.lift.bro.ui.navigation.Destination

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardReducer.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardReducer.kt
@@ -25,8 +25,6 @@ val dashboardReducer = Reducer<DashboardState, DashboardEvent> { state, event ->
         } else {
             state
         }
-        DashboardEvent.DismissAnalyticsBanner -> state
-        DashboardEvent.EnableAnalytics -> state
     }.let { newState ->
         when (newState) {
             is Loaded -> newState.copy(

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardScreen.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardScreen.kt
@@ -38,6 +38,7 @@ import com.lift.bro.ui.card.lift.LiftCard
 import com.lift.bro.ui.theme.spacing
 import lift_bro.core.generated.resources.Res
 import lift_bro.core.generated.resources.dashboard_footer_version
+import lift_bro.core.generated.resources.dashboard_lift_header_title
 import org.jetbrains.compose.resources.stringResource
 import tv.dpal.compose.padding.horizontal.padding
 
@@ -88,7 +89,7 @@ fun DashboardContent(
                                 DashboardLiftHeader(
                                     v2 = item.v3,
                                     showRpe = showRpe,
-                                    title = "Categories",
+                                    title = stringResource(Res.string.dashboard_lift_header_title),
                                     showTempo = showTempo,
                                     sortingSettings = state.sortingSettings,
                                     onToggleRpe = { showRpe = !showRpe },

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardScreen.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/DashboardScreen.kt
@@ -5,9 +5,6 @@ package com.lift.bro.presentation.dashboard
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,8 +14,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -32,14 +27,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.lift.bro.core.buildconfig.BuildKonfig
 import com.lift.bro.presentation.LocalLiftCardYValue
 import com.lift.bro.presentation.dashboard.DashboardEvent.LiftClicked
+import com.lift.bro.presentation.dashboard.carousel.DashboardBannerCarousel
 import com.lift.bro.presentation.workout.WorkoutCalendarContent
 import com.lift.bro.ui.Card
-import com.lift.bro.ui.ReleaseNotesRow
 import com.lift.bro.ui.card.lift.LiftCard
 import com.lift.bro.ui.theme.spacing
 import lift_bro.core.generated.resources.Res
@@ -78,10 +72,6 @@ fun DashboardContent(
                 val numOddItems by remember { mutableStateOf(state.items.sumOf { it.gridSize(state.items.size) % 2 }) }
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(2),
-                    contentPadding = PaddingValues(
-                        horizontal = MaterialTheme.spacing.half,
-                        vertical = MaterialTheme.spacing.half
-                    ),
                     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.half),
                     verticalArrangement = Arrangement.spacedBy(MaterialTheme.spacing.half),
                 ) {
@@ -90,63 +80,8 @@ fun DashboardContent(
                         span = { index, item -> GridItemSpan(item.gridSize(state.items.size)) }
                     ) { index, item ->
                         when (item) {
-                            is DashboardListItem.AnalyticsBanner -> {
-                                Card(
-                                    modifier = Modifier.padding(
-                                        vertical = MaterialTheme.spacing.one
-                                    )
-                                ) {
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Column(
-                                            modifier = Modifier.weight(1f)
-                                                .padding(start = MaterialTheme.spacing.one),
-                                        ) {
-                                            Text(
-                                                text = "Help Lift Bro improve!",
-                                                style = MaterialTheme.typography.titleMedium
-                                            )
-                                            Text(
-                                                text = "Share usage info like:\n" +
-                                                    "⦁ Screen Names\n" +
-                                                    "⦁ Button Clicks\n",
-                                                style = MaterialTheme.typography.bodyMedium
-                                            )
-                                            Text(
-                                                text = "NO personal info",
-                                                style = MaterialTheme.typography.bodyMedium,
-                                                fontWeight = FontWeight.Bold,
-                                            )
-                                            Row(
-                                                modifier = Modifier.align(Alignment.End)
-                                            ) {
-                                                Button(
-                                                    colors = ButtonDefaults.textButtonColors(),
-                                                    onClick = {
-                                                        interactor(DashboardEvent.DismissAnalyticsBanner)
-                                                    }
-                                                ) {
-                                                    Text("No Thanks!")
-                                                }
-                                                Button(
-                                                    onClick = {
-                                                        interactor(DashboardEvent.EnableAnalytics)
-                                                    }
-                                                ) {
-                                                    Text("Share data")
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            DashboardListItem.ReleaseNotes -> {
-                                ReleaseNotesRow(
-                                    modifier = Modifier.height(72.dp)
-                                        .padding(horizontal = MaterialTheme.spacing.half)
-                                )
+                            is DashboardListItem.Banner -> {
+                                DashboardBannerCarousel()
                             }
 
                             is DashboardListItem.LiftHeader -> {
@@ -230,7 +165,6 @@ fun DashboardContent(
 private fun DashboardListItem.gridSize(listSize: Int = 0): Int = when (this) {
     is DashboardListItem.LiftCard -> 1
     is DashboardListItem.LiftHeader -> 2
-    DashboardListItem.ReleaseNotes -> 2
     DashboardListItem.WorkoutCalendar -> 2
-    DashboardListItem.AnalyticsBanner -> 2
+    DashboardListItem.Banner -> 2
 }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
@@ -23,22 +23,33 @@ fun rememberBannerCarouselInteractor(
     analytics: Analytics = dependencies.analytics,
 ): DashboardBannerCarouselInteractor = rememberInteractor(
     initialState = DashboardBannerCarouselState(),
-    source = { state ->
+    source = {
         combine(
             settingsRepository.listen(Setting.AnalyticsConsent),
             settingsRepository.listen(Setting.LatestReadReleaseNotes),
-            flow { emit(Json.decodeFromString<List<ReleaseNote>>(Res.readBytes("files/release_notes.json").decodeToString())) }
+            flow {
+                emit(
+                    Json.decodeFromString<List<ReleaseNote>>(Res.readBytes("files/release_notes.json").decodeToString())
+                )
+            }
         ) { consent, lastReadReleaseNotes, releaseNotes ->
             DashboardBannerCarouselState(
+                latestReleaseNote = releaseNotes.maxOfOrNull { it.versionId },
                 banners = listOfNotNull(
-                    if (releaseNotes.maxOfOrNull { it.versionId } != lastReadReleaseNotes) DashboardBanner.ReleaseNotes(releaseNotes) else null,
+                    if (releaseNotes.maxOfOrNull { it.versionId } != lastReadReleaseNotes) {
+                        DashboardBanner.ReleaseNotes(
+                            releaseNotes
+                        )
+                    } else {
+                        null
+                    },
                     if (!consent.dashboardBannerDismissed) DashboardBanner.AnalyticsConsent else null,
                 )
             )
         }
     },
     sideEffects = listOf(
-        SideEffect { _, _, event ->
+        SideEffect { _, state, event ->
             when (event) {
                 DashboardBannerEvent.DismissAnalyticsBanner -> {
                     settingsRepository.set(
@@ -48,13 +59,19 @@ fun rememberBannerCarouselInteractor(
                     analytics.setConsent(false)
                 }
 
+                DashboardBannerEvent.ReleaseNotesSeen, DashboardBannerEvent.DismissReleaseNotes -> {
+                    settingsRepository.set(
+                        Setting.LatestReadReleaseNotes,
+                        state.latestReleaseNote,
+                    )
+                }
+
                 DashboardBannerEvent.EnableAnalytics -> {
                     settingsRepository.set(
                         Setting.AnalyticsConsent,
                         AnalyticsConsent(true, true)
                     )
                     analytics.setConsent(true)
-
                 }
             }
         }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
@@ -1,0 +1,62 @@
+package com.lift.bro.presentation.dashboard.carousel
+
+import androidx.compose.runtime.Composable
+import com.lift.bro.di.dependencies
+import com.lift.bro.domain.analytics.Analytics
+import com.lift.bro.domain.models.settings.AnalyticsConsent
+import com.lift.bro.domain.repositories.ISettingsRepository
+import com.lift.bro.domain.repositories.Setting
+import com.lift.bro.ui.ReleaseNote
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.Json
+import lift_bro.core.generated.resources.Res
+import tv.dpal.flowvi.Interactor
+import tv.dpal.flowvi.SideEffect
+import tv.dpal.flowvi.rememberInteractor
+
+typealias DashboardBannerCarouselInteractor = Interactor<DashboardBannerCarouselState, DashboardBannerEvent>
+
+@Composable
+fun rememberBannerCarouselInteractor(
+    settingsRepository: ISettingsRepository = dependencies.settingsRepository,
+    analytics: Analytics = dependencies.analytics,
+): DashboardBannerCarouselInteractor = rememberInteractor(
+    initialState = DashboardBannerCarouselState(),
+    source = { state ->
+        combine(
+            settingsRepository.listen(Setting.AnalyticsConsent),
+            settingsRepository.listen(Setting.LatestReadReleaseNotes),
+            flow { emit(Json.decodeFromString<List<ReleaseNote>>(Res.readBytes("files/release_notes.json").decodeToString())) }
+        ) { consent, lastReadReleaseNotes, releaseNotes ->
+            DashboardBannerCarouselState(
+                banners = listOfNotNull(
+                    if (releaseNotes.maxOfOrNull { it.versionId } != lastReadReleaseNotes) DashboardBanner.ReleaseNotes(releaseNotes) else null,
+                    if (!consent.dashboardBannerDismissed) DashboardBanner.AnalyticsConsent else null,
+                )
+            )
+        }
+    },
+    sideEffects = listOf(
+        SideEffect { _, _, event ->
+            when (event) {
+                DashboardBannerEvent.DismissAnalyticsBanner -> {
+                    settingsRepository.set(
+                        Setting.AnalyticsConsent,
+                        AnalyticsConsent(true, false)
+                    )
+                    analytics.setConsent(false)
+                }
+
+                DashboardBannerEvent.EnableAnalytics -> {
+                    settingsRepository.set(
+                        Setting.AnalyticsConsent,
+                        AnalyticsConsent(true, true)
+                    )
+                    analytics.setConsent(true)
+
+                }
+            }
+        }
+    )
+)

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
@@ -19,7 +19,6 @@ import com.lift.bro.ui.theme.spacing
 import kotlin.math.absoluteValue
 import kotlin.math.sign
 
-
 @Composable
 fun DashboardBannerCarousel(
     interactor: DashboardBannerCarouselInteractor = rememberBannerCarouselInteractor(),
@@ -37,7 +36,6 @@ fun DashboardBannerCarousel(
     onEvent: (DashboardBannerEvent) -> Unit,
 ) {
     val pagerState = rememberPagerState { state.banners.size }
-
 
     HorizontalPager(
         state = pagerState,
@@ -83,8 +81,8 @@ fun DashboardBannerCarousel(
 
             is DashboardBanner.ReleaseNotes -> ReleaseNotesRow(
                 modifier = animationModifier,
-                dialogSeen = {},
-                rowDismissed = {},
+                dialogSeen = { onEvent(DashboardBannerEvent.ReleaseNotesSeen) },
+                rowDismissed = { onEvent(DashboardBannerEvent.DismissReleaseNotes) },
             )
         }
     }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
@@ -1,0 +1,91 @@
+package com.lift.bro.presentation.dashboard.carousel
+
+import androidx.compose.foundation.gestures.snapping.SnapPosition
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import androidx.compose.ui.zIndex
+import com.lift.bro.ui.AnalyticsConsentBanner
+import com.lift.bro.ui.ReleaseNotesRow
+import com.lift.bro.ui.theme.spacing
+import kotlin.math.absoluteValue
+import kotlin.math.sign
+
+
+@Composable
+fun DashboardBannerCarousel(
+    interactor: DashboardBannerCarouselInteractor = rememberBannerCarouselInteractor(),
+) {
+    val state by interactor.state.collectAsState()
+    DashboardBannerCarousel(
+        state = state,
+        onEvent = { interactor(it) }
+    )
+}
+
+@Composable
+fun DashboardBannerCarousel(
+    state: DashboardBannerCarouselState,
+    onEvent: (DashboardBannerEvent) -> Unit,
+) {
+    val pagerState = rememberPagerState { state.banners.size }
+
+
+    HorizontalPager(
+        state = pagerState,
+        pageSpacing = 0.dp,
+        contentPadding = PaddingValues(horizontal = MaterialTheme.spacing.half),
+        snapPosition = SnapPosition.Center,
+        beyondViewportPageCount = state.banners.size,
+    ) { page ->
+        val pageOffset = (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+
+        val animationModifier = Modifier
+            .zIndex(1f - pageOffset.absoluteValue)
+            .graphicsLayer {
+                alpha = lerp(
+                    start = .4f,
+                    stop = 1f,
+                    fraction = 1f - pageOffset.absoluteValue
+                )
+                val nativeTranslationX = pageOffset * size.width
+
+                val peekDistance = 60.dp.toPx()
+
+                val fanTranslationX = -pageOffset.sign * peekDistance * pageOffset.absoluteValue.coerceIn(0f, 1f)
+
+                translationX = nativeTranslationX + fanTranslationX
+
+                lerp(
+                    start = 0.9f,
+                    stop = 1f,
+                    fraction = 1f - pageOffset.absoluteValue.coerceIn(0f, 1f),
+                ).also { scale ->
+                    scaleX = scale
+                    scaleY = scale
+                }
+            }
+
+        when (state.banners[page]) {
+            DashboardBanner.AnalyticsConsent -> AnalyticsConsentBanner(
+                modifier = animationModifier,
+                onDismiss = { onEvent(DashboardBannerEvent.DismissAnalyticsBanner) },
+                onEnable = { onEvent(DashboardBannerEvent.EnableAnalytics) }
+            )
+
+            is DashboardBanner.ReleaseNotes -> ReleaseNotesRow(
+                modifier = animationModifier,
+                dialogSeen = {},
+                rowDismissed = {},
+            )
+        }
+    }
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DashboardBannerCarouselState(
+    val latestReleaseNote: String? = null,
     val banners: List<DashboardBanner> = emptyList(),
 )
 
@@ -22,5 +23,6 @@ sealed class DashboardBanner {
 sealed interface DashboardBannerEvent {
     data object EnableAnalytics: DashboardBannerEvent
     data object DismissAnalyticsBanner: DashboardBannerEvent
-
+    data object ReleaseNotesSeen: DashboardBannerEvent
+    data object DismissReleaseNotes: DashboardBannerEvent
 }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
@@ -1,0 +1,26 @@
+package com.lift.bro.presentation.dashboard.carousel
+
+import com.lift.bro.ui.ReleaseNote
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DashboardBannerCarouselState(
+    val banners: List<DashboardBanner> = emptyList(),
+)
+
+@Serializable
+sealed class DashboardBanner {
+    @Serializable
+    data class ReleaseNotes(
+        val notes: List<ReleaseNote>,
+    ): DashboardBanner()
+
+    @Serializable
+    data object AnalyticsConsent: DashboardBanner()
+}
+
+sealed interface DashboardBannerEvent {
+    data object EnableAnalytics: DashboardBannerEvent
+    data object DismissAnalyticsBanner: DashboardBannerEvent
+
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AnalyticsConsentBanner.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AnalyticsConsentBanner.kt
@@ -1,0 +1,45 @@
+package com.lift.bro.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.lift.bro.ui.theme.spacing
+import tv.dpal.compose.padding.horizontal.padding
+
+@Composable
+fun AnalyticsConsentBanner(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    onEnable: () -> Unit,
+) {
+    com.lift.bro.ui.banner.DashboardBanner(
+        modifier = modifier,
+        onDismiss = onDismiss,
+        onClick = onEnable,
+        onClickLabel = "Enable Analytics",
+    ) {
+        Column(
+            modifier = Modifier.padding(start = MaterialTheme.spacing.one),
+        ) {
+            Text(
+                text = "Help Lift Bro improve!",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = "Share usage info (Screen Names, Button Clicks)",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = "NO personal info",
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = "Enable",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+    }
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AnalyticsConsentBanner.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AnalyticsConsentBanner.kt
@@ -6,6 +6,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.lift.bro.ui.theme.spacing
+import lift_bro.core.generated.resources.Res
+import lift_bro.core.generated.resources.analytics_consent_banner_action
+import lift_bro.core.generated.resources.analytics_consent_banner_detail
+import lift_bro.core.generated.resources.analytics_consent_banner_onclick_label
+import lift_bro.core.generated.resources.analytics_consent_banner_privacy
+import lift_bro.core.generated.resources.analytics_consent_banner_title
+import org.jetbrains.compose.resources.stringResource
 import tv.dpal.compose.padding.horizontal.padding
 
 @Composable
@@ -18,25 +25,25 @@ fun AnalyticsConsentBanner(
         modifier = modifier,
         onDismiss = onDismiss,
         onClick = onEnable,
-        onClickLabel = "Enable Analytics",
+        onClickLabel = stringResource(Res.string.analytics_consent_banner_onclick_label),
     ) {
         Column(
             modifier = Modifier.padding(start = MaterialTheme.spacing.one),
         ) {
             Text(
-                text = "Help Lift Bro improve!",
+                text = stringResource(Res.string.analytics_consent_banner_title),
                 style = MaterialTheme.typography.titleMedium
             )
             Text(
-                text = "Share usage info (Screen Names, Button Clicks)",
+                text = stringResource(Res.string.analytics_consent_banner_detail),
                 style = MaterialTheme.typography.bodyMedium
             )
             Text(
-                text = "NO personal info",
+                text = stringResource(Res.string.analytics_consent_banner_privacy),
                 style = MaterialTheme.typography.bodyMedium,
             )
             Text(
-                text = "Enable",
+                text = stringResource(Res.string.analytics_consent_banner_action),
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.secondary,
             )

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/ReleaseNotesRow.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/ReleaseNotesRow.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import lift_bro.core.generated.resources.Res
+import lift_bro.core.generated.resources.release_notes_release_notes_close_content_description
 import lift_bro.core.generated.resources.release_notes_row_new_update_title
 import lift_bro.core.generated.resources.release_notes_row_tap_subtitle
 import org.jetbrains.compose.resources.stringResource
@@ -48,7 +49,7 @@ fun ReleaseNotesRow(
             showDialog = true
         },
         onDismiss = rowDismissed,
-        onClickLabel = null,
+        onClickLabel = stringResource(Res.string.release_notes_release_notes_close_content_description),
     ) {
         Column(
             modifier = Modifier.padding(start = MaterialTheme.spacing.one),

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/ReleaseNotesRow.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/ReleaseNotesRow.kt
@@ -7,32 +7,23 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.lift.bro.di.dependencies
-import com.lift.bro.domain.repositories.Setting
 import com.lift.bro.ui.theme.spacing
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import lift_bro.core.generated.resources.Res
-import lift_bro.core.generated.resources.release_notes_row_ignore_content_description
 import lift_bro.core.generated.resources.release_notes_row_new_update_title
 import lift_bro.core.generated.resources.release_notes_row_tap_subtitle
 import org.jetbrains.compose.resources.stringResource
@@ -40,65 +31,36 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun ReleaseNotesRow(
     modifier: Modifier = Modifier,
-    forceShow: Boolean = false,
+    dialogSeen: () -> Unit,
+    rowDismissed: () -> Unit,
 ) {
-    var releaseNotes: List<ReleaseNote> by remember { mutableStateOf(emptyList()) }
-
-    val latestReleaseNote by remember { derivedStateOf { releaseNotes.maxByOrNull { it.versionId } } }
-    val latestReadReleaseNotes by dependencies.settingsRepository.listen(
-        Setting.LatestReadReleaseNotes
-    ).collectAsState(null)
-
-    LaunchedEffect(Unit) {
-        launch {
-            releaseNotes = Json.decodeFromString(
-                Res.readBytes("files/release_notes.json").decodeToString()
-            )
-        }
-    }
-
-    if (latestReleaseNote == null || latestReleaseNote?.versionId == latestReadReleaseNotes || !forceShow) return
-
     var showDialog by remember { mutableStateOf(false) }
     if (showDialog) {
         ReleaseNotesDialog {
             showDialog = false
-            dependencies.settingsRepository.set(Setting.LatestReadReleaseNotes, latestReleaseNote!!.versionId)
+            dialogSeen()
         }
     }
 
-    Card(
+    com.lift.bro.ui.banner.DashboardBanner(
         modifier = modifier,
         onClick = {
             showDialog = true
-        }
+        },
+        onDismiss = rowDismissed,
+        onClickLabel = null,
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
+        Column(
+            modifier = Modifier.padding(start = MaterialTheme.spacing.one),
         ) {
-            Column(
-                modifier = Modifier.weight(1f).padding(start = MaterialTheme.spacing.one),
-            ) {
-                Text(
-                    text = stringResource(Res.string.release_notes_row_new_update_title),
-                    style = MaterialTheme.typography.titleMedium
-                )
-                Text(
-                    text = stringResource(Res.string.release_notes_row_tap_subtitle),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-
-            IconButton(
-                onClick = {
-                    dependencies.settingsRepository.set(Setting.LatestReadReleaseNotes, latestReleaseNote!!.versionId)
-                }
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(Res.string.release_notes_row_ignore_content_description)
-                )
-            }
+            Text(
+                text = stringResource(Res.string.release_notes_row_new_update_title),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = stringResource(Res.string.release_notes_row_tap_subtitle),
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/banner/DashboardBanner.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/banner/DashboardBanner.kt
@@ -1,0 +1,57 @@
+package com.lift.bro.ui.banner
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.semantics.Role
+import com.lift.bro.ui.Card
+import com.lift.bro.ui.Space
+import lift_bro.core.generated.resources.Res
+import lift_bro.core.generated.resources.release_notes_row_ignore_content_description
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun DashboardBanner(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    onClick: () -> Unit,
+    onClickLabel: String? = null,
+    content: @Composable () -> Unit,
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        backgroundBrush = Brush.linearGradient(
+            colors = listOf(
+                MaterialTheme.colorScheme.surface,
+                MaterialTheme.colorScheme.surface,
+            )
+        ),
+        onClick = {
+            onClick()
+        }
+    ) {
+        Row {
+            content()
+            Space()
+            IconButton(
+                onClick = {
+                    onDismiss()
+                }
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(Res.string.release_notes_row_ignore_content_description)
+                )
+            }
+        }
+    }
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/banner/DashboardBanner.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/banner/DashboardBanner.kt
@@ -1,6 +1,5 @@
 package com.lift.bro.ui.banner
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
@@ -9,15 +8,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.semantics.Role
 import com.lift.bro.ui.Card
 import com.lift.bro.ui.Space
-import lift_bro.core.generated.resources.Res
-import lift_bro.core.generated.resources.release_notes_row_ignore_content_description
-import org.jetbrains.compose.resources.stringResource
 
 @Composable
 fun DashboardBanner(
@@ -49,7 +43,7 @@ fun DashboardBanner(
             ) {
                 Icon(
                     imageVector = Icons.Default.Close,
-                    contentDescription = stringResource(Res.string.release_notes_row_ignore_content_description)
+                    contentDescription = onClickLabel,
                 )
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard now shows an interactive banner carousel for release notes and announcements, including an analytics consent banner with enable/dismiss actions and a release-notes card that opens a dialog.
  * Dashboard lift header relabeled to "Categories" and layout ordering improved for calendar and banners.

* **Documentation**
  * Release notes data updated with new entries for the latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eholtrop/lift-bro/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->