### PR TITLE
Opt in translations

### DIFF
--- a/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISettingsRepository.kt
+++ b/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISettingsRepository.kt
@@ -36,6 +36,7 @@ sealed interface Setting<T> {
     data object ClientUrl: Setting<String?>
     data object AnalyticsConsent: Setting<com.lift.bro.domain.models.settings.AnalyticsConsent>
     data object LocaleOverride: Setting<String?>
+    data object AITranslationBannerDismissed: Setting<Boolean>
 }
 
 interface ISettingsRepository {

--- a/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISettingsRepository.kt
+++ b/domain/src/commonMain/kotlin/com/lift/bro/domain/repositories/ISettingsRepository.kt
@@ -35,6 +35,7 @@ sealed interface Setting<T> {
     data object TMaxEnabled: Setting<Boolean>
     data object ClientUrl: Setting<String?>
     data object AnalyticsConsent: Setting<com.lift.bro.domain.models.settings.AnalyticsConsent>
+    data object LocaleOverride: Setting<String?>
 }
 
 interface ISettingsRepository {

--- a/presentation/compose/src/androidMain/kotlin/com/lift/bro/presentation/LocalLocale.android.kt
+++ b/presentation/compose/src/androidMain/kotlin/com/lift/bro/presentation/LocalLocale.android.kt
@@ -1,0 +1,36 @@
+package com.lift.bro.presentation
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.intl.Locale
+import androidx.core.os.LocaleListCompat
+
+actual object LocalLocale {
+
+    actual val current: String
+        @Composable
+        get() = Locale.current.toLanguageTag()
+
+    @Composable
+    actual infix fun provides(value: String?): ProvidedValue<*> {
+        val override = value ?: current
+
+        LaunchedEffect(value) {
+            when (value) {
+                null -> LocaleListCompat.getEmptyLocaleList()
+                else -> LocaleListCompat.forLanguageTags(value)
+            }.also {
+                AppCompatDelegate.setApplicationLocales(it)
+            }
+        }
+        java.util.Locale.setDefault(java.util.Locale.forLanguageTag(override))
+
+        return with(LocalConfiguration.current) {
+            setLocale(java.util.Locale.forLanguageTag(override))
+            LocalConfiguration.provides(LocalConfiguration.current)
+        }
+    }
+}

--- a/presentation/compose/src/androidMain/kotlin/com/lift/bro/presentation/LocalLocale.android.kt
+++ b/presentation/compose/src/androidMain/kotlin/com/lift/bro/presentation/LocalLocale.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.ProvidedValue
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.intl.Locale
 import androidx.core.os.LocaleListCompat
+import java.util.Locale as AndroidLocale
 
 actual object LocalLocale {
 
@@ -26,7 +27,10 @@ actual object LocalLocale {
                 AppCompatDelegate.setApplicationLocales(it)
             }
         }
-        java.util.Locale.setDefault(java.util.Locale.forLanguageTag(override))
+
+        LaunchedEffect(override) {
+            AndroidLocale.setDefault(AndroidLocale.forLanguageTag(override))
+        }
 
         return with(LocalConfiguration.current) {
             setLocale(java.util.Locale.forLanguageTag(override))

--- a/presentation/compose/src/commonMain/composeResources/files/release_notes.json
+++ b/presentation/compose/src/commonMain/composeResources/files/release_notes.json
@@ -1,5 +1,15 @@
 [
     {
+        "versionId": "2026.06.12",
+        "notes": [
+            {
+                "type": "feature",
+                "platform": "all",
+                "en": "Allow language switching in settings"
+            }
+        ]
+    },
+    {
         "versionId": "2026.06.10",
         "notes": [
             {
@@ -10,7 +20,7 @@
             {
                 "type": "feature",
                 "platform": "all",
-                "en": "Relelase The Edit Set Screen V2!! \uD83C\uDF89"
+                "en": "Release The Edit Set Screen V2!! \uD83C\uDF89"
             },
             {
                 "type": "fix",

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/repository/SettingsRepository.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/repository/SettingsRepository.kt
@@ -74,6 +74,7 @@ class SettingsRepository(
             Setting.Timer -> dataSource.putBool(key, value as Boolean)
             Setting.AnalyticsConsent -> dataSource.putSerializable(key, value as AnalyticsConsent)
             Setting.UnitOfMeasure -> dataSource.putString(key, (value as Settings.UnitOfWeight).uom.toString())
+            Setting.LocaleOverride -> dataSource.putString(key, value as String?)
         }
         keyChanged(key)
     }
@@ -96,6 +97,7 @@ class SettingsRepository(
             Setting.Timer -> "timer_feature_flag"
             Setting.UnitOfMeasure -> "unit_of_measure"
             Setting.AnalyticsConsent -> "analytics_consent"
+            Setting.LocaleOverride -> "locale_override"
         }
 
     @Suppress("UNCHECKED_CAST")
@@ -130,6 +132,7 @@ class SettingsRepository(
             Setting.ThemeMode -> dataSource.getString(key, null)?.let { ThemeMode.valueOf(it) } ?: ThemeMode.System
             Setting.Timer -> dataSource.getBool(key, false)
             Setting.UnitOfMeasure -> Settings.UnitOfWeight(UOM.valueOf(dataSource.getString(key, "POUNDS") ?: "POUNDS"))
+            Setting.LocaleOverride -> dataSource.getString(key, null)
         } as T
     }
 

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/repository/SettingsRepository.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/data/repository/SettingsRepository.kt
@@ -75,6 +75,7 @@ class SettingsRepository(
             Setting.AnalyticsConsent -> dataSource.putSerializable(key, value as AnalyticsConsent)
             Setting.UnitOfMeasure -> dataSource.putString(key, (value as Settings.UnitOfWeight).uom.toString())
             Setting.LocaleOverride -> dataSource.putString(key, value as String?)
+            Setting.AITranslationBannerDismissed -> dataSource.putBool(key, value as Boolean)
         }
         keyChanged(key)
     }
@@ -98,6 +99,7 @@ class SettingsRepository(
             Setting.UnitOfMeasure -> "unit_of_measure"
             Setting.AnalyticsConsent -> "analytics_consent"
             Setting.LocaleOverride -> "locale_override"
+            Setting.AITranslationBannerDismissed -> "ai_translations_banner_dismissed"
         }
 
     @Suppress("UNCHECKED_CAST")
@@ -133,6 +135,7 @@ class SettingsRepository(
             Setting.Timer -> dataSource.getBool(key, false)
             Setting.UnitOfMeasure -> Settings.UnitOfWeight(UOM.valueOf(dataSource.getString(key, "POUNDS") ?: "POUNDS"))
             Setting.LocaleOverride -> dataSource.getString(key, null)
+            Setting.AITranslationBannerDismissed -> dataSource.getBool(key, false)
         } as T
     }
 

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/App.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/App.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -143,6 +144,10 @@ val LocalServer = compositionLocalOf<LiftBroServer?> {
     null
 }
 
+// val LocalLocale = compositionLocalOf {
+//    Locale.current
+// }
+
 @OptIn(DelicateCoroutinesApi::class)
 val ApplicationScope = GlobalScope
 
@@ -234,7 +239,10 @@ fun App(
     val showPaywall = remember { mutableStateOf(false) }
     val showCalculator = remember { mutableStateOf(false) }
 
+    val localLocale by dependencies.settingsRepository.listen(Setting.LocaleOverride).collectAsState(null)
+
     CompositionLocalProvider(
+        LocalLocale provides localLocale,
         LocalLiftBro provides (bro ?: if (Random.nextBoolean()) LiftBro.Leo else LiftBro.Lisa),
         LocalUnitOfMeasure provides uom,
         LocalShowMERCalcs provides showMerCalcs,
@@ -273,132 +281,134 @@ fun App(
 
         val themeMode by dependencies.settingsRepository.listen(Setting.ThemeMode).collectAsState(ThemeMode.System)
 
-        AppTheme(
-            theme = themeMode
-        ) {
-            Box(
-                modifier = modifier,
+        key(localLocale) {
+            AppTheme(
+                theme = themeMode
             ) {
-                if (navCoordinator.currentPage != Destination.Onboarding) {
-                    CheckAppConsent()
-                }
-                BackupAlertDialog()
-
-                Column {
-                    SwipeableNavHost<Destination>(
-                        modifier = Modifier.weight(1f),
-                        navCoordinator = navCoordinator,
-                    ) { route ->
-                        AppRouter(route)
-                    }
-                }
-
-                val options = remember {
-                    PaywallOptions(dismissRequest = { showPaywall.value = false }) {
-                        shouldDisplayDismissButton = true
-                    }
-                }
-
-                AnimatedVisibility(
-                    visible = showPaywall.value,
-                    enter = slideInVertically { it },
-                    exit = slideOutVertically { it } + fadeOut()
+                Box(
+                    modifier = modifier,
                 ) {
-                    Paywall(options)
-                }
+                    if (navCoordinator.currentPage != Destination.Onboarding) {
+                        CheckAppConsent()
+                    }
+                    BackupAlertDialog()
 
-                WeightCalculatorBottomSheet()
-
-                // This is all pretty terrible.... but its something I promised a friend id release before they hit PR!... and I got bugs to fix
-                var celebration by remember { mutableStateOf<CelebrationType>(CelebrationType.None) }
-
-                LaunchedEffect(Unit) {
-                    GetCelebrationTypeUseCase(
-                        setRepository = dependencies.setRepository,
-                        variationRepository = dependencies.variationRepository
-                    )
-                        .collectLatest {
-                            celebration = it
+                    Column {
+                        SwipeableNavHost<Destination>(
+                            modifier = Modifier.weight(1f),
+                            navCoordinator = navCoordinator,
+                        ) { route ->
+                            AppRouter(route)
                         }
-                }
+                    }
 
-                if (celebration != CelebrationType.None) {
-                    Box(
-                        modifier = Modifier.fillMaxSize()
+                    val options = remember {
+                        PaywallOptions(dismissRequest = { showPaywall.value = false }) {
+                            shouldDisplayDismissButton = true
+                        }
+                    }
+
+                    AnimatedVisibility(
+                        visible = showPaywall.value,
+                        enter = slideInVertically { it },
+                        exit = slideOutVertically { it } + fadeOut()
                     ) {
-                        ConfettiExplosion()
+                        Paywall(options)
+                    }
 
-                        var showMessage by remember { mutableStateOf(false) }
-                        AnimatedVisibility(
-                            modifier = Modifier.align(Alignment.Center),
-                            visible = showMessage,
-                            enter = fadeIn() + slideInVertically(initialOffsetY = { it / 2 }),
-                            exit = fadeOut(),
+                    WeightCalculatorBottomSheet()
+
+                    // This is all pretty terrible.... but its something I promised a friend id release before they hit PR!... and I got bugs to fix
+                    var celebration by remember { mutableStateOf<CelebrationType>(CelebrationType.None) }
+
+                    LaunchedEffect(Unit) {
+                        GetCelebrationTypeUseCase(
+                            setRepository = dependencies.setRepository,
+                            variationRepository = dependencies.variationRepository
+                        )
+                            .collectLatest {
+                                celebration = it
+                            }
+                    }
+
+                    if (celebration != CelebrationType.None) {
+                        Box(
+                            modifier = Modifier.fillMaxSize()
                         ) {
-                            val speechBubbleColor = MaterialTheme.colorScheme.primary
-                            Column {
-                                Column(
-                                    modifier = Modifier
-                                        .semantics(
-                                            mergeDescendants = true,
-                                        ) {
-                                            liveRegion = LiveRegionMode.Assertive
-                                        }
-                                        .background(
-                                            speechBubbleColor,
-                                            shape = MaterialTheme.shapes.medium
-                                        )
-                                        .padding(MaterialTheme.spacing.one),
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    Text(
-                                        text = stringResource(Res.string.app_congrats_text),
-                                        style = MaterialTheme.typography.headlineLarge,
-                                        color = MaterialTheme.colorScheme.onPrimary,
-                                    )
-                                    Space(MaterialTheme.spacing.half)
-                                    Text(
-                                        text = when (val cel = celebration) {
-                                            is CelebrationType.NewEMax -> "New estimated Max!"
-                                            is CelebrationType.NewOneRepMax -> "New one rep max!"
-                                            CelebrationType.None -> ""
-                                        },
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        color = MaterialTheme.colorScheme.onPrimary
-                                    )
-                                }
-                                Row {
-                                    Image(
+                            ConfettiExplosion()
+
+                            var showMessage by remember { mutableStateOf(false) }
+                            AnimatedVisibility(
+                                modifier = Modifier.align(Alignment.Center),
+                                visible = showMessage,
+                                enter = fadeIn() + slideInVertically(initialOffsetY = { it / 2 }),
+                                exit = fadeOut(),
+                            ) {
+                                val speechBubbleColor = MaterialTheme.colorScheme.primary
+                                Column {
+                                    Column(
                                         modifier = Modifier
-                                            .size(72.dp),
-                                        painter = painterResource(LocalLiftBro.current.iconRes()),
-                                        contentDescription = ""
-                                    )
-                                    Canvas(
-                                        modifier = Modifier.size(72.dp.div(2))
+                                            .semantics(
+                                                mergeDescendants = true,
+                                            ) {
+                                                liveRegion = LiveRegionMode.Assertive
+                                            }
+                                            .background(
+                                                speechBubbleColor,
+                                                shape = MaterialTheme.shapes.medium
+                                            )
+                                            .padding(MaterialTheme.spacing.one),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
                                     ) {
-                                        drawPath(
-                                            Path().apply {
-                                                moveTo(20f, 0f)
-                                                lineTo(0f, 60f)
-                                                lineTo(60f, 0f)
-                                                lineTo(0f, 0f)
-                                                close()
-                                            },
-                                            speechBubbleColor
+                                        Text(
+                                            text = stringResource(Res.string.app_congrats_text),
+                                            style = MaterialTheme.typography.headlineLarge,
+                                            color = MaterialTheme.colorScheme.onPrimary,
                                         )
+                                        Space(MaterialTheme.spacing.half)
+                                        Text(
+                                            text = when (val cel = celebration) {
+                                                is CelebrationType.NewEMax -> "New estimated Max!"
+                                                is CelebrationType.NewOneRepMax -> "New one rep max!"
+                                                CelebrationType.None -> ""
+                                            },
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = MaterialTheme.colorScheme.onPrimary
+                                        )
+                                    }
+                                    Row {
+                                        Image(
+                                            modifier = Modifier
+                                                .size(72.dp),
+                                            painter = painterResource(LocalLiftBro.current.iconRes()),
+                                            contentDescription = ""
+                                        )
+                                        Canvas(
+                                            modifier = Modifier.size(72.dp.div(2))
+                                        ) {
+                                            drawPath(
+                                                Path().apply {
+                                                    moveTo(20f, 0f)
+                                                    lineTo(0f, 60f)
+                                                    lineTo(60f, 0f)
+                                                    lineTo(0f, 0f)
+                                                    close()
+                                                },
+                                                speechBubbleColor
+                                            )
+                                        }
                                     }
                                 }
                             }
-                        }
 
-                        LaunchedEffect(Unit) {
-                            delay(1000)
-                            showMessage = true
-                            delay(4000)
-                            showMessage = false
-                            delay(2000)
-                            celebration = CelebrationType.None
+                            LaunchedEffect(Unit) {
+                                delay(1000)
+                                showMessage = true
+                                delay(4000)
+                                showMessage = false
+                                delay(2000)
+                                celebration = CelebrationType.None
+                            }
                         }
                     }
                 }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/LocalLocale.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/LocalLocale.kt
@@ -1,0 +1,11 @@
+package com.lift.bro.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+
+expect object LocalLocale {
+    val current: String
+
+    @Composable
+    infix fun provides(value: String?): ProvidedValue<*>
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/BannerCarouselInteractor.kt
@@ -20,6 +20,7 @@ typealias DashboardBannerCarouselInteractor = Interactor<DashboardBannerCarousel
 @Composable
 fun rememberBannerCarouselInteractor(
     settingsRepository: ISettingsRepository = dependencies.settingsRepository,
+    showLanguageBannerUseCase: ShowLanguageBannerUserCase = ShowLanguageBannerUserCase(),
     analytics: Analytics = dependencies.analytics,
 ): DashboardBannerCarouselInteractor = rememberInteractor(
     initialState = DashboardBannerCarouselState(),
@@ -27,12 +28,13 @@ fun rememberBannerCarouselInteractor(
         combine(
             settingsRepository.listen(Setting.AnalyticsConsent),
             settingsRepository.listen(Setting.LatestReadReleaseNotes),
+            showLanguageBannerUseCase(),
             flow {
                 emit(
                     Json.decodeFromString<List<ReleaseNote>>(Res.readBytes("files/release_notes.json").decodeToString())
                 )
             }
-        ) { consent, lastReadReleaseNotes, releaseNotes ->
+        ) { consent, lastReadReleaseNotes, showLanguageBanner, releaseNotes ->
             DashboardBannerCarouselState(
                 latestReleaseNote = releaseNotes.maxOfOrNull { it.versionId },
                 banners = listOfNotNull(
@@ -44,6 +46,7 @@ fun rememberBannerCarouselInteractor(
                         null
                     },
                     if (!consent.dashboardBannerDismissed) DashboardBanner.AnalyticsConsent else null,
+                    if (showLanguageBanner) DashboardBanner.AITranslations else null,
                 )
             )
         }
@@ -73,6 +76,18 @@ fun rememberBannerCarouselInteractor(
                     )
                     analytics.setConsent(true)
                 }
+
+                DashboardBannerEvent.AllowAITranslations,
+                DashboardBannerEvent.AITranslationBannerDismissed, ->
+                    settingsRepository.set(
+                        Setting.AITranslationBannerDismissed,
+                        true,
+                    )
+
+                DashboardBannerEvent.DisableAITranslations -> settingsRepository.set(
+                    Setting.LocaleOverride,
+                    "en",
+                )
             }
         }
     )

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarousel.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import androidx.compose.ui.zIndex
+import com.lift.bro.ui.AITranslationsConsentBanner
 import com.lift.bro.ui.AnalyticsConsentBanner
 import com.lift.bro.ui.ReleaseNotesRow
 import com.lift.bro.ui.theme.spacing
@@ -89,6 +90,19 @@ fun DashboardBannerCarousel(
                 modifier = animationModifier,
                 dialogSeen = { onEvent(DashboardBannerEvent.ReleaseNotesSeen) },
                 rowDismissed = { onEvent(DashboardBannerEvent.DismissReleaseNotes) },
+            )
+
+            DashboardBanner.AITranslations -> AITranslationsConsentBanner(
+                modifier = animationModifier,
+                onEnable = {
+                    onEvent(DashboardBannerEvent.AllowAITranslations)
+                },
+                onDisableAI = {
+                    onEvent(DashboardBannerEvent.DisableAITranslations)
+                },
+                onDismiss = {
+                    onEvent(DashboardBannerEvent.AITranslationBannerDismissed)
+                }
             )
         }
     }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/DashboardBannerCarouselState.kt
@@ -18,6 +18,9 @@ sealed class DashboardBanner {
 
     @Serializable
     data object AnalyticsConsent: DashboardBanner()
+
+    @Serializable
+    data object AITranslations: DashboardBanner()
 }
 
 sealed interface DashboardBannerEvent {
@@ -25,4 +28,7 @@ sealed interface DashboardBannerEvent {
     data object DismissAnalyticsBanner: DashboardBannerEvent
     data object ReleaseNotesSeen: DashboardBannerEvent
     data object DismissReleaseNotes: DashboardBannerEvent
+    data object AllowAITranslations: DashboardBannerEvent
+    data object AITranslationBannerDismissed: DashboardBannerEvent
+    data object DisableAITranslations: DashboardBannerEvent
 }

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/ShowLanguageBannerUserCase.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/dashboard/carousel/ShowLanguageBannerUserCase.kt
@@ -1,0 +1,28 @@
+package com.lift.bro.presentation.dashboard.carousel
+
+import androidx.compose.ui.text.intl.Locale
+import com.lift.bro.config.BuildConfig
+import com.lift.bro.di.dependencies
+import com.lift.bro.domain.repositories.ISettingsRepository
+import com.lift.bro.domain.repositories.Setting
+import com.lift.bro.presentation.settings.isAiGen
+import com.lift.bro.presentation.settings.supportedLanguage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+class ShowLanguageBannerUserCase(
+    private val settingsRepository: ISettingsRepository = dependencies.settingsRepository,
+) {
+
+    operator fun invoke(): Flow<Boolean> = combine(
+        settingsRepository.listen(Setting.AITranslationBannerDismissed),
+        settingsRepository.listen(Setting.LocaleOverride),
+    ) { bannerDismissed, overrideLocale ->
+        !bannerDismissed &&
+            (
+                Locale.current.language.supportedLanguage()?.isAiGen() == true ||
+                    overrideLocale != null ||
+                    BuildConfig.isDebug
+                )
+    }
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/LanguageSettingsRow.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/LanguageSettingsRow.kt
@@ -43,6 +43,11 @@ fun SupportedLanguage.languageTag(): String = when (this) {
     SupportedLanguage.Spanish -> "es"
 }
 
+fun SupportedLanguage.isAiGen(): Boolean = when (this) {
+    SupportedLanguage.English -> false
+    else -> true
+}
+
 enum class SupportedLanguage {
     English,
     French,
@@ -105,7 +110,7 @@ fun LanguageSettingsRow() {
                         Column {
                             SupportedLanguage.entries.forEach {
                                 RadioField(
-                                    text = it.languageName(),
+                                    text = "${it.languageName()}${if (it.isAiGen()) " (AI Gen)" else ""}",
                                     selected = selectedLanguage == it,
                                     fieldSelected = {
                                         selectedLanguage = it

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/LanguageSettingsRow.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/LanguageSettingsRow.kt
@@ -1,0 +1,129 @@
+package com.lift.bro.presentation.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.lift.bro.di.dependencies
+import com.lift.bro.domain.repositories.Setting
+import com.lift.bro.presentation.LocalLocale
+import com.lift.bro.ui.RadioField
+import com.lift.bro.utils.DarkModeProvider
+import com.lift.bro.utils.PreviewAppTheme
+
+@Composable
+fun SupportedLanguage.languageName() = when (this) {
+    SupportedLanguage.English -> "English"
+    SupportedLanguage.Portugease -> "Portugease"
+    SupportedLanguage.French -> "French"
+    SupportedLanguage.Spanish -> "Spanish"
+}
+
+fun String.supportedLanguage(): SupportedLanguage? = when (this) {
+    "en" -> SupportedLanguage.English
+    "fr" -> SupportedLanguage.French
+    "pt" -> SupportedLanguage.Portugease
+    "es" -> SupportedLanguage.Spanish
+    else -> null
+}
+
+fun SupportedLanguage.languageTag(): String = when (this) {
+    SupportedLanguage.English -> "en"
+    SupportedLanguage.French -> "fr"
+    SupportedLanguage.Portugease -> "pt"
+    SupportedLanguage.Spanish -> "es"
+}
+
+enum class SupportedLanguage {
+    English,
+    French,
+    Portugease,
+    Spanish,
+}
+
+@Composable
+fun LanguageSettingsRow() {
+    SettingsRowItem(
+        title = {
+            Text("Language Settings")
+        },
+        content = {
+            var showDialog by remember { mutableStateOf(false) }
+            var selectedLanguage by remember {
+                mutableStateOf(
+                    LocalLocale.current.supportedLanguage() ?: SupportedLanguage.English
+                )
+            }
+
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = { showDialog = true },
+            ) {
+                Text(selectedLanguage.languageName())
+            }
+
+            if (showDialog) {
+                AlertDialog(
+                    onDismissRequest = {
+                        showDialog = false
+                    },
+                    confirmButton = {
+                        Button(
+                            onClick = {
+                                dependencies.settingsRepository.set(
+                                    Setting.LocaleOverride,
+                                    selectedLanguage.languageTag()
+                                )
+                                showDialog = false
+                            }
+                        ) {
+                            Text("Save")
+                        }
+                    },
+                    dismissButton = {
+                        Button(
+                            onClick = {
+                                showDialog = false
+                            }
+                        ) {
+                            Text("Cancel")
+                        }
+                    },
+                    title = {
+                        Text("Select a Language")
+                    },
+                    text = {
+                        Column {
+                            SupportedLanguage.entries.forEach {
+                                RadioField(
+                                    text = it.languageName(),
+                                    selected = selectedLanguage == it,
+                                    fieldSelected = {
+                                        selectedLanguage = it
+                                    }
+                                )
+                            }
+                        }
+                    }
+                )
+            }
+        }
+    )
+}
+
+@Preview
+@Composable
+fun LanguageSettingsRowPreview(@PreviewParameter(DarkModeProvider::class) isDarkMode: Boolean) {
+    PreviewAppTheme(isDarkMode = isDarkMode) {
+        LanguageSettingsRow()
+    }
+}

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/SettingsScreen.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/presentation/settings/SettingsScreen.kt
@@ -76,7 +76,6 @@ import lift_bro.core.generated.resources.url_privacy_policy
 import lift_bro.core.generated.resources.url_terms_and_conditions
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
-import tv.dpal.compose.padding.horizontal.padding
 
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
@@ -159,6 +158,10 @@ fun SettingsScreen() {
 
                 item {
                     BackupSettingsRow()
+                }
+
+                item {
+                    LanguageSettingsRow()
                 }
 
                 item {

--- a/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AITranslationsConsentBanner.kt
+++ b/presentation/compose/src/commonMain/kotlin/com/lift/bro/ui/AITranslationsConsentBanner.kt
@@ -1,0 +1,118 @@
+package com.lift.bro.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import com.lift.bro.ui.banner.DashboardBanner
+import com.lift.bro.ui.theme.spacing
+import lift_bro.core.generated.resources.Res
+import lift_bro.core.generated.resources.analytics_consent_banner_onclick_label
+import org.jetbrains.compose.resources.stringResource
+import tv.dpal.compose.padding.horizontal.padding
+
+@Composable
+fun AITranslationsConsentBanner(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
+    onEnable: () -> Unit,
+    onDisableAI: () -> Unit,
+) {
+    var showDialog by remember { mutableStateOf(false) }
+
+    if (showDialog) {
+        var enableAiTranslations by remember { mutableStateOf<Boolean?>(null) }
+        AlertDialog(
+            title = { Text("Lift Bro uses AI Translations") },
+            text = {
+                Column {
+                    Text(
+                        text = "Evan, while a native English speaker, " +
+                            "still struggles with it let alone other languages \uD83D\uDE05",
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+
+                    Space(MaterialTheme.spacing.half)
+
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = "So use at your own risk!",
+                        style = MaterialTheme.typography.titleMedium,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Space(MaterialTheme.spacing.half)
+
+                    Text(
+                        "This can be changed in settings at any time",
+                        style = MaterialTheme.typography.labelSmall
+                    )
+
+                    RadioField(
+                        text = "Enable AI Translations",
+                        selected = enableAiTranslations == true,
+                        fieldSelected = {
+                            enableAiTranslations = true
+                        }
+                    )
+
+                    RadioField(
+                        text = "Force English (Disable AI Translations)",
+                        selected = enableAiTranslations == false,
+                        fieldSelected = {
+                            enableAiTranslations = false
+                        }
+                    )
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        when (enableAiTranslations) {
+                            true -> onEnable()
+                            false -> onDisableAI()
+                            null -> {}
+                        }
+                        showDialog = false
+                    },
+                    enabled = enableAiTranslations != null
+                ) {
+                    Text("Save")
+                }
+            },
+            onDismissRequest = onDismiss
+        )
+    }
+
+    DashboardBanner(
+        modifier = modifier,
+        onDismiss = onDismiss,
+        onClick = {
+            showDialog = true
+        },
+        onClickLabel = stringResource(Res.string.analytics_consent_banner_onclick_label),
+    ) {
+        Column(
+            modifier = Modifier.padding(start = MaterialTheme.spacing.one),
+        ) {
+            Text(
+                text = "Lift Bro uses AI Translations",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = "Tap to Learn More",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+    }
+}

--- a/presentation/compose/src/nativeMain/kotlin/com/lift/bro/presentation/LocalLocale.native.kt
+++ b/presentation/compose/src/nativeMain/kotlin/com/lift/bro/presentation/LocalLocale.native.kt
@@ -1,0 +1,16 @@
+package com.lift.bro.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.ui.text.intl.Locale
+
+actual object LocalLocale {
+    actual val current: String
+        @Composable
+        get() = Locale.current.language
+
+    @Composable
+    actual infix fun provides(value: String?): ProvidedValue<*> {
+        TODO()
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a language selector in Settings (English, French, Portuguese, Spanish) to switch the app’s language and persist the choice.
  * Added an AI Translations banner on the dashboard, letting users enable AI translations, force English, or dismiss the banner (with your choice saved).
* **Bug Fixes**
  * Corrected a typo in a previous release note entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->