### PR TITLE
Use last commit date instead of build time for version strings

### DIFF
--- a/.github/workflows/nightly-android.yaml
+++ b/.github/workflows/nightly-android.yaml
@@ -50,6 +50,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew detekt --continue
 
   test:
@@ -65,6 +67,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew test
 
   screenshot-validation:
@@ -80,6 +84,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew :presentation:compose:validateDebugScreenshotTest -Pandroid.experimental.enableScreenshotTest=true
       - uses: actions/upload-artifact@v4
         if: failure()
@@ -100,6 +106,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.3

--- a/.github/workflows/nightly-android.yaml
+++ b/.github/workflows/nightly-android.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   LIFT_BRO_ADMOB_APP_ID: ${{ secrets.LIFT_BRO_ADMOB_APP_ID }}
   LIFT_BRO_AD_UNIT_ID: ${{ secrets.LIFT_BRO_AD_UNIT_ID }}
@@ -18,6 +21,9 @@ jobs:
       has_changes: ${{ steps.check.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - id: check
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -28,7 +34,7 @@ jobs:
               echo "has_changes=true" >> "$GITHUB_OUTPUT"
             else
               echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            end
+            fi
           fi
 
   lint:
@@ -37,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -50,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -63,6 +73,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -81,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   LIFT_BRO_AD_UNIT_ID: ${{ secrets.LIFT_BRO_AD_UNIT_ID }}
   LIFT_BRO_SENTRY_DSN: ${{ secrets.LIFT_BRO_SENTRY_DSN }}
@@ -14,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -25,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -36,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -24,6 +24,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew detekt --continue
 
   test:
@@ -37,6 +39,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew test
 
   screenshot-validation:
@@ -50,6 +54,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew :presentation:compose:validateDebugScreenshotTest -Pandroid.experimental.enableScreenshotTest=true
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -26,6 +26,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew detekt --continue
 
   test:
@@ -39,6 +41,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew test
 
   screenshot-validation:
@@ -52,6 +56,8 @@ jobs:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@v4
+      - name: Set commit date
+        run: echo "LIFT_BRO_COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y.%m.%d)" >> $GITHUB_ENV
       - run: ./gradlew :presentation:compose:validateDebugScreenshotTest -Pandroid.experimental.enableScreenshotTest=true
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/weekly-release.yaml
+++ b/.github/workflows/weekly-release.yaml
@@ -5,6 +5,9 @@ on:
     - cron: '0 2 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   LIFT_BRO_ADMOB_APP_ID: ${{ secrets.LIFT_BRO_ADMOB_APP_ID }}
   LIFT_BRO_AD_UNIT_ID: ${{ secrets.LIFT_BRO_AD_UNIT_ID }}
@@ -16,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -27,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -38,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -54,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -73,6 +84,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -94,9 +107,15 @@ jobs:
           fi
           xcode-select -p
           xcodebuild -version
-      - name: Compute last Monday version
+      - name: Get latest TestFlight build version
         id: version
-        run: echo "version=$(date -v-7d +%Y.%m.%d)" >> $GITHUB_OUTPUT
+        env:
+          APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+        run: |
+          VERSION=$(bundle exec fastlane ios latest_testflight_version 2>/dev/null | grep "^VERSION:" | sed 's/^VERSION://')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Submit for App Store review
         env:
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
@@ -109,6 +128,8 @@ jobs:
     needs: [lint, test, screenshot-validation]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -135,11 +156,8 @@ jobs:
           ssh-private-key: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
       - name: Build and Release to TestFlight
         env:
-          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_PASSWORD: ${{ secrets.FASTLANE_MATCH_PASSWORD }}
           APPSTORE_KEY_ID: ${{ secrets.APPSTORE_KEY_ID }}
-          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
-          APPSTORE_PRIVATE_KEY: ${{ secrets.APPSTORE_PRIVATE_KEY }}
+          APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }
           REVENUE_CAT_API_KEY: ${{ secrets.REVENUE_CAT_API_KEY_IOS }}
         run: bundle exec fastlane ios beta build_number:${{ github.run_number }}
       - uses: actions/upload-artifact@v4

--- a/buildSrc/src/main/kotlin/com/lift/bro/Versioning.kt
+++ b/buildSrc/src/main/kotlin/com/lift/bro/Versioning.kt
@@ -13,5 +13,6 @@ fun Project.versionCode(): Int {
 }
 
 fun Project.versionName(): String {
-    return SimpleDateFormat("yyyy.MM.dd").format(Date())
+    return System.getenv("LIFT_BRO_COMMIT_DATE")
+        ?: SimpleDateFormat("yyyy.MM.dd").format(Date())
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -283,6 +283,22 @@ platform :ios do
 #     )
   end
 
+  desc "Get the latest TestFlight build version"
+  lane :latest_testflight_version do
+    require 'spaceship'
+
+    builds = Spaceship::ConnectAPI::Build.all(
+      filter: { processingState: "VALID" },
+      sort: "-uploadedDate",
+      limit: 1
+    )
+
+    version = builds.first&.app_version
+    UI.user_error!("No valid TestFlight builds found - run ios-beta-build first") unless version
+
+    puts "VERSION:#{version}"
+  end
+
   desc "Submit existing TestFlight build for App Store review"
   lane :promote do |options|
     deliver(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -151,7 +151,7 @@ platform :ios do
       output_name: "ios_app_release.ipa",
       clean: true,
       silent: false,
-      xcargs: options[:build_number] ? "MARKETING_VERSION=#{Time.now.strftime('%Y.%m.%d')} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}" : nil,
+      xcargs: options[:build_number] ? "MARKETING_VERSION=#{`git log -1 --format=%cd --date=format:%Y.%m.%d`.strip} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}" : nil,
     )
   end
 
@@ -168,7 +168,7 @@ platform :ios do
       output_name: "ios_app_debug.ipa",
       clean: true,
       silent: false,
-      xcargs: options[:build_number] ? "MARKETING_VERSION=#{Time.now.strftime('%Y.%m.%d')} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}" : nil,
+      xcargs: options[:build_number] ? "MARKETING_VERSION=#{`git log -1 --format=%cd --date=format:%Y.%m.%d`.strip} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}" : nil,
     )
   end
 
@@ -185,7 +185,7 @@ platform :ios do
 
     xcargs = "PROVISIONING_PROFILE_SPECIFIER='match Development com.lift.bro' CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=VZPX29WT9H"
     if options[:build_number]
-      xcargs += " MARKETING_VERSION=#{Time.now.strftime('%Y.%m.%d')} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}"
+      xcargs += " MARKETING_VERSION=#{`git log -1 --format=%cd --date=format:%Y.%m.%d`.strip} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}"
     end
 
     gym(
@@ -219,7 +219,7 @@ platform :ios do
 
     xcargs = "CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM=VZPX29WT9H"
     if options[:build_number]
-      xcargs += " MARKETING_VERSION=#{Time.now.strftime('%Y.%m.%d')} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}"
+      xcargs += " MARKETING_VERSION=#{`git log -1 --format=%cd --date=format:%Y.%m.%d`.strip} CURRENT_PROJECT_VERSION=#{options[:build_number].to_i + 156}"
     end
 
     gym(


### PR DESCRIPTION
**What changed**\n- Fastfile: 4× `Time.now` replaced with `\`git log -1 --format=%cd --date=format:%Y.%m.%d\`.strip` for iOS marketing versions\n- `Versioning.kt`: reads `LIFT_BRO_COMMIT_DATE` env var for Android version name, falls back to `Date()` locally\n- Workflows: added `Set commit date` step in every Gradle job to export `LIFT_BRO_COMMIT_DATE` from the checked-out commit\n\n**Why**\nBuild numbers should reflect the specific code being built, not the build machine's clock. A commit pushed at 10pm on Monday but CI-built at 3am Tuesday should still show Monday's date.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Improvements**
  * Android and iOS builds now use consistent, date-based version names across automated releases.
  * iOS release workflows now identify the latest valid TestFlight version automatically.
  * Improved reliability of nightly, pull request, and weekly release checks.
  * Updated release configuration to provide more predictable build and deployment results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->